### PR TITLE
Anchor hero arrow to chat button and update CV content

### DIFF
--- a/components/AskAboutMe.tsx
+++ b/components/AskAboutMe.tsx
@@ -7,6 +7,8 @@ const DEFAULT_WIDTH = 384; // sm:w-96
 const DEFAULT_HEIGHT_VH = 70;
 const MAX_HEIGHT_PX = 512; // 32rem
 const MOBILE_BREAKPOINT = 640;
+const DETACHED_CHAT_URL =
+  "https://wendebot.vercel.app?detached&url=wss://wendebot.fly.dev&token=d5c63d4790b61d2404a1c8cddf93f5d1115c390cf0b02b013d38d044f3a57f9b";
 
 export const AskAboutMe: React.FC = () => {
   const [chatOpen, setChatOpen] = useState(false);
@@ -157,7 +159,7 @@ export const AskAboutMe: React.FC = () => {
             </>
           )}
           <iframe
-            src="https://wendebot.vercel.app?detached&url=wss://wendebot.fly.dev&token=d5c63d4790b61d2404a1c8cddf93f5d1115c390cf0b02b013d38d044f3a57f9b"
+            src={DETACHED_CHAT_URL}
             width="100%"
             height="100%"
             frameBorder="0"

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -13,7 +13,7 @@ export const Contact: React.FC = () => {
                     <AnimatedHeading text="GET IN TOUCH" />
                 </div>
                 <p className="text-xl text-gray-600 mb-8 max-w-md">
-                    Looking for a distributed systems architect or functional programming expert? Let's discuss how I can help.
+                    Looking for an Elixir specialist or distributed systems architect? Let's discuss how I can help.
                 </p>
                 
                 <div className="space-y-6">
@@ -45,6 +45,21 @@ export const Contact: React.FC = () => {
                             <span className="font-bold text-lg">GitHub</span>
                         </a>
                     </div>
+                </div>
+
+                <div className="bg-off-white p-8 border border-gray-100">
+                    <h3 className="text-sm font-bold uppercase tracking-widest mb-6 text-gray-400">Education</h3>
+                    <p className="text-lg font-bold text-ink">{CV_DATA.education.school}</p>
+                    <p className="text-gray-700">{CV_DATA.education.focus}</p>
+                    <p className="mt-3 text-sm text-gray-500 leading-relaxed">{CV_DATA.education.details}</p>
+                </div>
+
+                <div className="bg-off-white p-8 border border-gray-100">
+                    <h3 className="text-sm font-bold uppercase tracking-widest mb-6 text-gray-400">Community</h3>
+                    <p className="text-lg font-bold text-ink">{CV_DATA.community.role}</p>
+                    <p className="text-gray-700">{CV_DATA.community.organization}</p>
+                    <p className="mt-3 text-sm text-gray-500 leading-relaxed">{CV_DATA.community.description}</p>
+                    <p className="mt-3 font-mono text-xs uppercase tracking-wider text-gray-500">{CV_DATA.community.stats}</p>
                 </div>
 
                 <div className="bg-off-white p-8 border border-gray-100">

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -12,9 +12,8 @@ export const Hero: React.FC = () => {
   const [textState, dispatch] = useReducer(heroReducer, heroInitialState);
   const [showPop, setShowPop] = useState(false);
   const [arrowHidden, setArrowHidden] = useState(false);
-  const [chatClicked, setChatClicked] = useState(() => {
-    try { return !!localStorage.getItem('chat-arrow-dismissed'); } catch { return false; }
-  });
+  const [chatClicked, setChatClicked] = useState(false);
+  const [hasNarrativeStarted, setHasNarrativeStarted] = useState(false);
   const [isHovering, setIsHovering] = useState(false);
   const remainingRef = useRef<Record<string, number>>({});
   const mouseX = useSpring(0, { stiffness: 120, damping: 20 });
@@ -50,9 +49,9 @@ export const Hero: React.FC = () => {
 
   useEffect(() => {
     const onChatOpen = () => {
+      setHasNarrativeStarted(true);
       dispatch({ type: 'TREELOCATOR_ACTIVATED' });
       setChatClicked(true);
-      try { localStorage.setItem('chat-arrow-dismissed', '1'); } catch {}
     };
     window.addEventListener('chat-opened', onChatOpen);
     return () => window.removeEventListener('chat-opened', onChatOpen);
@@ -73,8 +72,29 @@ export const Hero: React.FC = () => {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
+  useEffect(() => {
+    if (hasNarrativeStarted) return;
+    const startNarrative = () => setHasNarrativeStarted(true);
+    const passiveOptions: AddEventListenerOptions = { passive: true };
+
+    window.addEventListener('pointerdown', startNarrative, passiveOptions);
+    window.addEventListener('keydown', startNarrative);
+    window.addEventListener('wheel', startNarrative, passiveOptions);
+    window.addEventListener('touchstart', startNarrative, passiveOptions);
+    window.addEventListener('scroll', startNarrative, passiveOptions);
+
+    return () => {
+      window.removeEventListener('pointerdown', startNarrative);
+      window.removeEventListener('keydown', startNarrative);
+      window.removeEventListener('wheel', startNarrative);
+      window.removeEventListener('touchstart', startNarrative);
+      window.removeEventListener('scroll', startNarrative);
+    };
+  }, [hasNarrativeStarted]);
+
   // Generic timed transition: auto-advances any state that has a duration in heroTimerDurations
   useEffect(() => {
+    if (!hasNarrativeStarted) return;
     const duration = heroTimerDurations[textState];
     if (!duration) { delete remainingRef.current[textState]; return; }
     if (isHovering) return;
@@ -88,7 +108,7 @@ export const Hero: React.FC = () => {
       clearTimeout(timer);
       remainingRef.current[textState] = Math.max(0, remaining - (Date.now() - start));
     };
-  }, [textState, isHovering]);
+  }, [textState, isHovering, hasNarrativeStarted]);
 
   // Pop effect halfway through dismissed state
   useEffect(() => {
@@ -165,23 +185,28 @@ export const Hero: React.FC = () => {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ delay: 0.5, duration: 0.8 }}
-            className="max-w-2xl"
+            className="max-w-3xl"
         >
-             <h2 className="text-xl md:text-2xl font-light text-gray-800 mb-8 leading-relaxed">
+             <h2 className="text-xl md:text-2xl font-light text-gray-800 mb-4 md:mb-8 leading-relaxed">
                 {CV_DATA.title}
              </h2>
-             <div className="flex flex-wrap gap-4 text-sm font-medium text-gray-600 mb-12">
-                 <span className="px-4 py-2 border border-gray-200 bg-white shadow-sm">Forbes 25 under 25</span>
-                 <span className="px-4 py-2 border border-gray-200 bg-white shadow-sm">Elixir Specialist</span>
-                 <span className="px-4 py-2 border border-gray-200 bg-white shadow-sm">Systems Architect</span>
+             <div className="hidden md:flex flex-wrap gap-4 text-sm font-medium text-gray-600 mb-12">
+                 {CV_DATA.highlights.map((highlight) => (
+                    <span key={highlight} className="px-4 py-2 border border-gray-200 bg-white shadow-sm">
+                       {highlight}
+                    </span>
+                 ))}
              </div>
         </motion.div>
 
         {!boring && (
-        <div className="flex justify-center items-center w-full min-h-[12rem] md:min-h-[16rem]">
+        <div className="flex justify-center items-center w-full min-h-[8rem] md:min-h-[10rem] mb-24 md:mb-8">
           <motion.p
             className="text-5xl md:text-7xl font-sans font-bold text-ink select-none leading-tight text-center cursor-pointer"
-            onClick={() => dispatch({ type: 'CLICK' })}
+            onClick={() => {
+              setHasNarrativeStarted(true);
+              dispatch({ type: 'CLICK' });
+            }}
             onMouseEnter={() => setIsHovering(true)}
             onMouseLeave={() => setIsHovering(false)}
             style={{
@@ -234,22 +259,36 @@ export const Hero: React.FC = () => {
       <AnimatePresence>
       {!chatClicked && (textState === 'default' || textState === 'resumed' || textState === 'meta') && (
       <motion.div
-        className="absolute bottom-16 right-12 md:right-20 pointer-events-none mr-2 mb-2"
+        // Chat button is fixed bottom-8 right-8, w-14 h-14: center = (60, 60) in
+        // right/bottom viewport px. The SVG tip is at viewBox (100, 88), i.e. 20px
+        // from the SVG's right edge and 12px above its bottom. The curve arrives at
+        // the tip heading 45° down-right, so the tip must sit on that 45° diagonal
+        // up-left of the button center for its heading to aim through the center:
+        // tip at (60+29, 60+29) = (89, 89) → container right: 69, bottom: 77.
+        className="fixed right-[69px] bottom-[77px] z-[2147483645] pointer-events-none"
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0, transition: { duration: 0.4 } }}
         transition={{ delay: 1.5, duration: 0.3 }}
       >
+        {/* Button center in this coordinate space is (129, 117) — 29px down-right
+            of the tip (100, 88), on the tip's 45° heading line. Rotating this
+            wrapper about that point swings the arrow's body to fit narrow screens
+            while the tip orbits the button center with its heading still aimed
+            through it, so it can never point wrong. The label is inside the
+            wrapper so its anchor (bottom-center pinned to the artwork's
+            top-center) follows the rotation; the label itself counter-rotates
+            back to a constant -6° tilt. */}
+        <div className="relative origin-[129px_117px] -rotate-[40deg] md:rotate-0">
         <motion.p
-          className="text-lg md:text-xl font-sans italic text-gray-400 mb-2 translate-x-[-45px] md:translate-x-[-40px] md:rotate-[-6deg] translate-y-[4.5rem] md:translate-y-0"
+          className="absolute bottom-full left-1/2 -translate-x-1/2 rotate-[34deg] md:rotate-[-6deg] text-lg md:text-xl font-sans italic text-gray-500 whitespace-nowrap"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ delay: 1.5, duration: 0.5 }}
         >
           {textState === 'meta' ? 'Really. Try it!' : 'like this one'}
         </motion.p>
-        {/* Mobile: cropped 30% from left */}
-        <svg width="84" height="100" viewBox="36 0 84 100" fill="none" className="text-gray-400 translate-x-[6px] -rotate-[40deg] origin-bottom-right md:hidden">
+        <svg width="120" height="100" viewBox="0 0 120 100" fill="none" className="text-gray-500 overflow-visible">
           <motion.path
             d="M10 10 C 25 5, 40 2, 55 8 C 70 14, 78 30, 82 48 C 86 66, 90 78, 100 88"
             stroke="currentColor"
@@ -272,30 +311,7 @@ export const Hero: React.FC = () => {
             transition={{ delay: 2.6, duration: 0.15 }}
           />
         </svg>
-        {/* Desktop: full arrow */}
-        <svg width="120" height="100" viewBox="0 0 120 100" fill="none" className="text-gray-400 translate-x-[20px] hidden md:block">
-          <motion.path
-            d="M10 10 C 25 5, 40 2, 55 8 C 70 14, 78 30, 82 48 C 86 66, 90 78, 100 88"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            fill="none"
-            initial={{ pathLength: 0 }}
-            animate={{ pathLength: 1 }}
-            transition={{ delay: 1.6, duration: 1, ease: "easeInOut" }}
-          />
-          <motion.path
-            d="M94 80 L100 88 L90 86" transform="rotate(15, 100, 88)"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            fill="none"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ delay: 2.6, duration: 0.15 }}
-          />
-        </svg>
+        </div>
       </motion.div>
       )}
       </AnimatePresence>

--- a/components/Portfolio.tsx
+++ b/components/Portfolio.tsx
@@ -43,9 +43,9 @@ const iconMap: Record<string, React.FC<{ className?: string }>> = {
     "Cicada": IconCode,
     "Elchemy": IconStar,
     "Autocomplete Elixir": IconExternalLink,
-    "Forbes 25 under 25": IconAward,
+    "Forbes 25 Under 25": IconAward,
     "MobileClaw": IconMessage,
-    "Quora": IconTrending,
+    "BUZZArt / Idziemy Na Solo": IconTrending,
 };
 
 export const Portfolio: React.FC = () => {
@@ -57,7 +57,7 @@ export const Portfolio: React.FC = () => {
                 <AnimatedHeading text="SELECTED WORKS" />
             </div>
             <p className="text-muted mt-4 md:mt-0 max-w-sm text-right hidden md:block">
-                A showcase of open source contributions, awards, and impactful startups.
+                A showcase of open source projects, awards, startups, and community work.
             </p>
         </div>
 

--- a/constants.ts
+++ b/constants.ts
@@ -10,11 +10,18 @@ export const CV_DATA = {
     github: "wende",
     location: "Kraków, Poland"
   },
+  profile: "Distributed systems architect and Elixir specialist with 13 years of commercial experience. Background spanning AI agent infrastructure, real-time multimedia processing, water telemetry systems deployed across 20+ countries, telecom platforms, and open-source language design.",
+  highlights: [
+    "13 years commercial experience",
+    "Elixir / OTP specialist",
+    "AI agent infrastructure",
+    "Forbes 25 Under 25"
+  ],
   tldr: [
-    "Functional programming engineer with 10 years of commercial experience, including four years in executive roles and six years as an individual contributor.",
-    "Creator of Elchemy – a type-safe programming language for Erlang VM, heavily inspired by Elm and Haskell.",
-    "Forbes 25 under 25 awardee in New Technology category.",
-    "Strong at turning ambiguous distributed-systems and AI-product requirements into reliable production software."
+    "Distributed systems architect and Elixir specialist with 13 years of commercial experience.",
+    "Built AI agent infrastructure, real-time multimedia tooling, water telemetry systems deployed across 20+ countries, and telecom platforms.",
+    "Creator of Elchemy, a type-safe programming language for the Erlang VM inspired by Elm and Haskell.",
+    "Forbes 25 Under 25 awardee in New Technology category; founded and exited a transportation tech startup at age 19."
   ],
   experience: [
     {
@@ -22,10 +29,10 @@ export const CV_DATA = {
       company: "Thenvoi",
       location: "Remote",
       period: "2025-2026",
-      description: "Built core infrastructure for an agentic mesh platform: a secure communication layer that enables AI agents to discover capabilities, collaborate, and orchestrate tasks across teams and systems.",
+      description: "Built core infrastructure for the Agentic Mesh platform: a secure communication layer enabling AI agents to dynamically discover, collaborate, and orchestrate tasks.",
       responsibilities: [
-        "Implemented components for secure inter-agent messaging, capability discovery, and orchestration flows.",
-        "Built centralized agent-management features for lifecycle control and human-in-the-loop collaboration."
+        "Contributed to AI orchestration, inter-agent communication protocols built on open standards (MCP, A2A), and centralized agent management.",
+        "Developed human-agent collaboration features for shared working environments."
       ]
     },
     {
@@ -33,44 +40,43 @@ export const CV_DATA = {
       company: "Software Mansion",
       location: "Poland (Remote)",
       period: "2024-2025",
-      description: "Built observability tooling for Membrane Framework, an open-source Elixir multimedia framework for real-time audio and video processing (WebRTC, HLS, RTMP).",
+      description: "Contributed to Membrane Framework, an open-source multimedia streaming framework for Elixir supporting WebRTC, HLS, RTMP, and various codecs.",
       responsibilities: [
-        "Designed and implemented pipeline observability tooling for Membrane-based multimedia systems.",
-        "Improved diagnostics for real-time media pipelines to speed up debugging and production incident triage."
+        "Developed observability tooling for real-time multimedia processing pipelines."
       ]
     },
     {
       role: "Elixir Developer",
-      company: "Confly z o.o",
+      company: "Confly z o.o (Priv)",
       location: "Poland (Remote)",
       period: "2021-2023",
-      description: "Designed and built a telecom platform with VoIP and SMS support, enabling instantaneous acquisition of new numbers while ensuring compliance with Polish telecommunication regulations.",
+      description: "Designed and built the telecom platform for Priv, a virtual phone number app with VoIP and SMS, handling instantaneous number acquisition and Polish telecom compliance.",
       responsibilities: [
-        "Designed and developed an in-house Event Sourcing system",
-        "Designed and developed a telecommunication protocol responsible for handling VoIP calls"
+        "Designed and developed an in-house Event Sourcing system from scratch.",
+        "Designed and developed a custom VoIP telecommunication protocol."
       ]
     },
     {
       role: "Elixir Developer",
-      company: "Inflowmatix Ltd",
+      company: "Inflowmatix Ltd (acquired by SUEZ)",
       location: "Southampton, UK (Remote)",
       period: "2016-2021",
-      description: "One of the first three developers to lay the foundation for the InflowNet system, which is now used in over 20 countries by major water companies to deliver real-time telemetry data, preventing outages, bursts, and leakages.",
+      description: "One of the first three developers to build the InflowNet real-time water telemetry platform, now deployed in 20+ countries.",
       responsibilities: [
-        "Designed distributed Elixir services for high-throughput telemetry ingestion and processing (multi-gigabyte streams), with strict uptime and consistency targets.",
-        "Managed databases including InfluxDB, Mnesia, Timescale, and PostgresDB.",
-        "Implemented event-sourced architecture for critical telemetry workflows.",
-        "Designed a 20+ node AWS cluster for resilient processing and horizontal scaling."
+        "Designed a fully distributed Elixir architecture processing gigabytes/sec with 99.999% annual availability.",
+        "Managed databases including InfluxDB, Mnesia, TimescaleDB, and PostgreSQL.",
+        "Designed and operated a cluster of 20+ machines on AWS with event-sourced architecture."
       ]
     },
     {
-      role: "CEO",
+      role: "CEO / Founder",
       company: "Neon Tree Solutions Ltd",
-      location: "Kraków, London",
+      location: "Kraków & London",
       period: "2014-2021",
-      description: "Led a team of 3-5 in a software house building proofs of concept and experimental systems for contractors. Built the first prototype of the Erlang Performance Lab project.",
+      description: "Led a software consultancy of 3-5 engineers specializing in cutting-edge proofs of concept using Erlang, Elixir, Scala, React.js, and ReasonML.",
       responsibilities: [
-        "Technologies used: Erlang/Elixir, Scala, React.js, ReasonML"
+        "Responsible for the first prototype of the Erlang Performance Lab project.",
+        "Managed cross-border operations between Poland and the UK."
       ]
     },
     {
@@ -78,82 +84,92 @@ export const CV_DATA = {
       company: "Man La Mode LLC",
       location: "Kraków & Ann Arbor, MI",
       period: "2015-2016",
-      description: "Developed and oversaw a novel affiliate network allowing users to purchase fashion goods directly from the source at significant discounts.",
+      description: "Built the backend in Elixir and oversaw frontend development in React.js for a luxury fashion buyers club.",
       responsibilities: [
-        "Developed the back-end in Elixir.",
-        "Oversaw front-end development in React.js.",
-        "Engaged with investors."
+        "Engaged directly with investors in Ann Arbor, Michigan."
       ]
     },
     {
       role: "CTO / Co-founder",
-      company: "CloudCab LLC",
+      company: "CloudCab LLC → LightDispatch (acquired by WideTech)",
       location: "New York (Remote)",
       period: "2013-2015",
-      description: "Developed a modern dispatch system for ride-hailing, medical material, and cargo transportation operators; later acquired by WideTech (18+ countries).",
+      description: "Built a white-label B2B dispatch platform for taxi, medical, and cargo transportation; later acquired by WideTech, a Colombian GPS/fleet company operating in 18+ countries.",
       responsibilities: [
-        "Developed and oversaw both customer and driver apps in Java for Android.",
-        "Developed the back-end in Node.js.",
-        "Oversaw the front-end fleet dispatch administrative panel.",
+        "Developed Android apps for customers and drivers, a Node.js backend, and a fleet dispatch admin panel.",
         "Led a team of four."
       ]
     }
   ] as Experience[],
   portfolio: [
     {
+      name: "Forbes 25 Under 25",
+      description: "Awardee in the New Technology category by Forbes Poland and McKinsey & Company.",
+      stats: "New Technology Category (2020)"
+    },
+    {
       name: "Cicada",
-      description: "Code Intelligence for AI Assistants. Token-efficient code indexing via MCP for Elixir, Python, and 17 other languages.",
-      stats: "Internal coding-assistant benchmarks: up to 50% faster responses and up to 70% fewer tokens",
+      description: "AST-based code intelligence MCP server for AI assistants, built around tree-sitter and SCIP.",
+      stats: "17+ languages; up to 50% faster responses and 70% fewer tokens",
       link: "https://github.com/wende/cicada"
     },
     {
       name: "Elchemy",
-      description: "Strongly typed Erlang VM Language. Heavily inspired by Elm and Haskell.",
-      stats: "Over 1000 Stars on Github",
+      description: "Statically typed language for the Erlang VM, inspired by Elm and Haskell.",
+      stats: "1,000+ GitHub stars",
       link: "https://github.com/wende/elchemy"
     },
     {
       name: "Autocomplete Elixir",
-      description: "#1 Most popular Elixir and Erlang plugin for Atom Editor.",
-      stats: "Over 60,000 downloads"
-    },
-    {
-      name: "Forbes 25 under 25",
-      description: "Awardee in New Technology Category",
-      stats: "Forbes 2020"
+      description: "#1 most popular Elixir/Erlang plugin for Atom Editor, with semantic completion via live BEAM introspection.",
+      stats: "60,000+ downloads",
+      link: "https://github.com/wende/autocomplete-elixir"
     },
     {
       name: "MobileClaw",
-      description: "Built an open-source AI chat client for OpenClaw and LM Studio, focused on responsive UX across desktop and mobile.",
-      stats: "Open source AI chat client",
+      description: "Open-source mobile-first AI chat client for OpenClaw and LM Studio with streaming, tool execution display, inline diffs, and sub-agent feeds.",
+      stats: "Open-source AI chat client",
       link: "https://github.com/wende/mobileclaw"
     },
     {
-      name: "Quora",
-      description: "Active knowledge sharing.",
-      stats: "Over 350,000 answer reads"
+      name: "BUZZArt / Idziemy Na Solo",
+      description: "Founder and president of a culture-focused NGO running a free music production program in Gdańsk.",
+      stats: "7 editions; 130 songs released; KPO/EU funded"
     }
   ] as Project[],
   skills: [
     {
-      category: "AI & Agents",
-      items: ["Agentic Architectures", "AI-Assisted Development", "Code Intelligence Tooling", "LLM Integration", "Prompt Engineering", "Local Model Deployment"]
-    },
-    {
-      category: "Distributed Systems",
-      items: [
-        "Elixir / OTP / BEAM",
-        "Event-Sourced Architectures",
-        "Fault-Tolerant Cluster Architecture",
-        "InfluxDB, Mnesia, TimescaleDB, PostgreSQL",
-        "VoIP / SIP / RTP & SMS Gateways",
-        "WebRTC / HLS / RTMP / RTSP"
-      ]
-    },
-    {
       category: "Core Technologies",
-      items: ["Elixir", "Erlang", "TypeScript", "Distributed Systems", "Event-Sourcing"]
+      items: ["Elixir", "Erlang/OTP", "TypeScript", "Distributed Systems", "Event Sourced Architecture"]
+    },
+    {
+      category: "AI & Agents",
+      items: ["Agentic Architectures", "MCP Servers", "A2A", "LLM Integration", "Local Model Deployment"]
+    },
+    {
+      category: "Developer Tooling",
+      items: ["Code Intelligence (AST/tree-sitter)", "Language Design", "Editor Tooling", "Data Pipelines"]
+    },
+    {
+      category: "Frontend",
+      items: ["React.js", "Next.js", "Tailwind CSS"]
+    },
+    {
+      category: "Infrastructure",
+      items: ["InfluxDB", "TimescaleDB", "PostgreSQL", "VoIP/SIP/RTP"]
     }
   ] as Skill[],
-  hobbies: ["Fusion Jazz", "Percussion/Drums", "Nutrition", "Psychology", "Coffee", "Indie Games", "Traveling"]
+  education: {
+    school: "Jagiellonian University in Kraków",
+    focus: "Theoretical Computer Science",
+    details: "Left after one semester in 2013 to take the CTO role at CloudCab, New York."
+  },
+  community: {
+    role: "Founder & President",
+    organization: "Stowarzyszenie Twórców Kultury BUZZArt",
+    description: "Runs Idziemy Na Solo, a free music production program in Gdańsk.",
+    stats: "7 editions, 130 songs released, KPO/EU funded",
+    period: "2022-present"
+  },
+  hobbies: ["Fusion jazz", "Drums & percussion (17 years)", "Recording studio owner", "Indie games", "Nutrition", "Psychology", "Coffee"]
 };

--- a/heroFsm.ts
+++ b/heroFsm.ts
@@ -19,6 +19,7 @@ const transitions: Record<HeroState, Partial<Record<HeroEvent['type'], HeroState
   default: {
     SCROLL: 'scrolled',
     CLICK: 'always',
+    TIMEOUT: 'always',
     TREELOCATOR_ACTIVATED: 'activated',
   },
   scrolled: {
@@ -35,6 +36,7 @@ const transitions: Record<HeroState, Partial<Record<HeroEvent['type'], HeroState
   },
   resumed: {
     CLICK: 'always',
+    TIMEOUT: 'always',
     TREELOCATOR_ACTIVATED: 'activated',
   },
   always: {
@@ -68,17 +70,21 @@ const transitions: Record<HeroState, Partial<Record<HeroEvent['type'], HeroState
   greatday: {},
   activated: {
     CLICK: 'keepgoing',
+    TIMEOUT: 'keepgoing',
   },
 };
 
 export const heroTimerDurations: Partial<Record<HeroState, number>> = {
   returning: 4000,
+  default: 4500,
   scrolled: 3000,
   returned: 1500,
   dismissed: 3000,
+  resumed: 4500,
   always: 3000,
   everything: 3500,
   anyways: 1000,
+  activated: 2500,
   keepgoing: 3500,
   withyou: 3000,
   whoknows: 3000,
@@ -112,11 +118,11 @@ export function heroReducer(state: HeroState, event: HeroEvent): HeroState {
 
 export const heroText: Record<HeroState, string> = {
   returning: "Oh hi! You're back!",
-  default: 'I love building tools...',
+  default: 'I love building things...',
   scrolled: "Wait. Don't go",
   returned: 'Phew. Alright. Where was I?',
   dismissed: "We won't be needing that",
-  resumed: 'So I love building tools...',
+  resumed: 'So I love building things...',
   always: 'Always have.',
   everything: 'Apps. Workshops. Open source.',
   meta: 'I even turned this CV into one',

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-    <title>Krzysztof Wende | Software Architect</title>
+    <title>Krzysztof Wende | Software Engineer & Distributed Systems Architect</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@100;400;700&family=Manrope:wght@200;300;400;500;600;700;800&family=Space+Grotesk:wght@300;400;500;600;700&family=Montserrat:wght@400&display=swap" rel="stylesheet">

--- a/metadata.json
+++ b/metadata.json
@@ -1,4 +1,4 @@
 {
   "name": "Krzysztof Wende - Portfolio",
-  "description": "Interactive minimalist portfolio for Software Engineer & Architect Krzysztof Wende."
+  "description": "Interactive portfolio for Software Engineer and Distributed Systems Architect Krzysztof Wende."
 }


### PR DESCRIPTION
## What changed

**Hero arrow (components/Hero.tsx)**
- The hand-drawn arrow pointing at the chat button was positioned with a pile of per-breakpoint translates and an `origin-bottom-right` rotation, which let the tip drift off-target (and off-screen) depending on viewport size.
- It is now anchored mathematically: the chat button is `fixed bottom-8 right-8 w-14 h-14`, so its center is deterministic. The arrow tip sits on its own 45° heading line through the button center, and the mobile `-40deg` rotation pivots around the button center itself — so the tip points at the middle of the button at any rotation angle, by construction. Tuning the mobile angle is now a one-number change.
- The "like this one" / "Really. Try it!" label is pinned bottom-center to the artwork's top-center inside the rotated wrapper and counter-rotates to keep a constant -6° tilt, so it follows the arrow wherever it swings instead of relying on hand-tuned offsets.
- The original curve and arrowhead artwork and all drawing animations are unchanged.

**Content updates**
- Contact: new Education and Community sections driven from `CV_DATA`, updated intro copy.
- Portfolio: renamed entries ("Forbes 25 Under 25", "BUZZArt / Idziemy Na Solo"), updated section blurb.
- Hero narrative: "tools" → "things" copy tweak; more FSM states auto-advance on a timer (default, resumed, activated).
- AskAboutMe: chat iframe URL extracted to a constant.

## How it was verified

Screenshotted the running app at 1280×800 and 375×600 in both the `default` and `meta` narrative states: the arrow tip lands on the button pointing at its center in all cases, and the label stays clear of the floating hero text.